### PR TITLE
feat(plugin): Watch for changes to dark mode

### DIFF
--- a/prefers-dark.js
+++ b/prefers-dark.js
@@ -1,11 +1,22 @@
-function prefersDark() {
-  return !!window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+function checkDarkMode() {
+  return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
 }
 
-if (prefersDark()) {
-  // use your theme's class below
-  document.documentElement.classList.add('theme-dark')
-} else {
-  // use your theme's class below
-  document.documentElement.classList.remove('theme-dark')
+function watchDarkMode() {
+  if (!window.matchMedia) return;
+
+  window.matchMedia('(prefers-color-scheme: dark)').addListener(addDarkModeSelector);
 }
+
+function addDarkModeSelector() {
+  if (checkDarkMode()) {
+    // use your theme's class below
+    document.documentElement.classList.add('theme-dark');
+  } else {
+    // use your theme's class below
+    document.documentElement.classList.remove('theme-dark');
+  }
+}
+
+addDarkModeSelector();
+watchDarkMode();


### PR DESCRIPTION
👋 Hi, right now when people visit a website using the `prefers-dark.js` script, it'll only set the theme at the beginning when they load the page, so if they change their system theme afterward, it won't be updated on the site. 

This pull request, which is modeled after https://github.com/ChanceArthur/tailwindcss-dark-mode/pull/34, fixes that by using the [listener / observer feature of `matchMedia`](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener).