### PR TITLE
fix invalid 'main' entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tailwindcss-multi-theme",
   "version": "0.0.0-development",
   "description": "The easiest way to create themes with Tailwind CSS.",
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "files": [
     "dist",
     "prefers-dark.js",


### PR DESCRIPTION
I don't see a `dist` directory in the project. This causes errors when using with more strict package managers like pnpm.